### PR TITLE
Update mout to 1.2.3 to address security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "is-hexcolor": "^1.0.0",
-    "mout": "^1.2.2"
+    "mout": "^1.2.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",


### PR DESCRIPTION
Update the version of mout in the dependencies to address https://github.com/advisories/GHSA-vvv8-xw5f-3f88